### PR TITLE
use tee to maintain sudo permission for append

### DIFF
--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -25,9 +25,9 @@ namespace :mb do
         unless test(:sudo, "grep -qs sidekiq_#{application_basename}.service /etc/sudoers.d/#{user}")
           execute :sudo, "touch -f /etc/sudoers.d/#{user}"
           execute :sudo, "chmod u+w /etc/sudoers.d/#{user}"
-          execute :sudo, "echo '#{user} ALL=NOPASSWD: /bin/systemctl start sidekiq_#{application_basename}.service' >> /etc/sudoers.d/#{user}"
-          execute :sudo, "echo '#{user} ALL=NOPASSWD: /bin/systemctl stop sidekiq_#{application_basename}.service' >> /etc/sudoers.d/#{user}"
-          execute :sudo, "echo '#{user} ALL=NOPASSWD: /bin/systemctl restart sidekiq_#{application_basename}.service' >> /etc/sudoers.d/#{user}"
+          execute :sudo, "echo '#{user} ALL=NOPASSWD: /bin/systemctl start sidekiq_#{application_basename}.service' | sudo tee -a /etc/sudoers.d/#{user}"
+          execute :sudo, "echo '#{user} ALL=NOPASSWD: /bin/systemctl stop sidekiq_#{application_basename}.service' | sudo tee -a /etc/sudoers.d/#{user}"
+          execute :sudo, "echo '#{user} ALL=NOPASSWD: /bin/systemctl restart sidekiq_#{application_basename}.service' | sudo tee -a /etc/sudoers.d/#{user}"
           execute :sudo, "chmod 440 /etc/sudoers.d/#{user}"
         end
       end

--- a/lib/capistrano/tasks/unicorn.rake
+++ b/lib/capistrano/tasks/unicorn.rake
@@ -25,9 +25,9 @@ namespace :mb do
         unless test(:sudo, "grep -qs unicorn_#{application_basename}.service /etc/sudoers.d/#{user}")
           execute :sudo, "touch -f /etc/sudoers.d/#{user}"
           execute :sudo, "chmod u+w /etc/sudoers.d/#{user}"
-          execute :sudo, "echo '#{user} ALL=NOPASSWD: /bin/systemctl start unicorn_#{application_basename}.service' >> /etc/sudoers.d/#{user}"
-          execute :sudo, "echo '#{user} ALL=NOPASSWD: /bin/systemctl stop unicorn_#{application_basename}.service' >> /etc/sudoers.d/#{user}"
-          execute :sudo, "echo '#{user} ALL=NOPASSWD: /bin/systemctl restart unicorn_#{application_basename}.service' >> /etc/sudoers.d/#{user}"
+          execute :sudo, "echo '#{user} ALL=NOPASSWD: /bin/systemctl start unicorn_#{application_basename}.service' | sudo tee -a /etc/sudoers.d/#{user}"
+          execute :sudo, "echo '#{user} ALL=NOPASSWD: /bin/systemctl stop unicorn_#{application_basename}.service' | sudo tee -a /etc/sudoers.d/#{user}"
+          execute :sudo, "echo '#{user} ALL=NOPASSWD: /bin/systemctl restart unicorn_#{application_basename}.service' | sudo tee -a /etc/sudoers.d/#{user}"
           execute :sudo, "chmod 440 /etc/sudoers.d/#{user}"
         end
       end


### PR DESCRIPTION
when setting `mb_privileged_user` to a non root user, the provision command will fail when appending to the user's sudoers file since redirects aren't performed by sudo. [`tee`](http://manpages.ubuntu.com/manpages/xenial/man1/tee.1.html) is available in both xenial and bionic and will allow for non root users to append to their sudoers file.